### PR TITLE
Trim element names before checking if they're the target

### DIFF
--- a/scripts/replay.js
+++ b/scripts/replay.js
@@ -5,7 +5,7 @@ var siteMacroReplay = {
         siteMacroReplay.started = true;
         siteMacroReplay.execute(steps, response);
         return true;
-    }, 
+    },
     execute: function(steps, response) {
         if(steps.length == 0) {
             response(chrome.i18n.getMessage("badgeCompleted"));
@@ -14,16 +14,16 @@ var siteMacroReplay = {
             if(step.type == "click") {
                 var elem = siteMacroReplay.elem(step.target);
                 if(!siteMacroReplay.checkElem(step, elem)) {
-                    response(chrome.i18n.getMessage("badgeFailed")); 
-                    return; 
+                    response(chrome.i18n.getMessage("badgeFailed"));
+                    return;
                 }
                 var event = new MouseEvent('click', { view: window, bubbles: true, cancelable: true });
                 elem.dispatchEvent(event);
             } else if(step.type == "change") {
                 var elem = siteMacroReplay.elem(step.target);
                 if(!siteMacroReplay.checkElem(step, elem)) {
-                    response(chrome.i18n.getMessage("badgeFailed")); 
-                    return; 
+                    response(chrome.i18n.getMessage("badgeFailed"));
+                    return;
                 }
                 elem.value = step.value;
             } else if(step.type == "wait") {
@@ -40,17 +40,17 @@ var siteMacroReplay = {
     },
     elem: function(xpath) {
         return document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
-    }, 
+    },
     checkElem: function(obj, elem) {
-        if(elem == null) { 
-            console.log("SiteMacro: Did not find element with path " + obj.target); 
-            return false; 
-        } else if(obj.name && elem.name != obj.name) {
-            console.log("SiteMacro: Element with path " + obj.target + " has name '" + elem.name + "' instead of '" + obj.name + "'"); 
+        if(elem == null) {
+            console.log("SiteMacro: Did not find element with path " + obj.target);
             return false;
-        } else if(obj.text && elem.innerText != obj.text) {
-            console.log("SiteMacro: Element with path " + obj.target + " has text '" + elem.innerText + "' instead of '" + obj.text + "'"); 
-            return false; 
+        } else if(obj.name && elem.name.trim() != obj.name) {
+            console.log("SiteMacro: Element with path " + obj.target + " has name '" + elem.name.trim() + "' instead of '" + obj.name + "'");
+            return false;
+        } else if(obj.text && elem.innerText.trim() != obj.text) {
+            console.log("SiteMacro: Element with path " + obj.target + " has text '" + elem.innerText.trim() + "' instead of '" + obj.text + "'");
+            return false;
         }
         return true;
     }


### PR DESCRIPTION
This is to address a problem where siteMacro reports things like:

> "SiteMacro: Element with path obj.button.accept has name '
>   Accept
> ' instead of 'Accept'

This happens when the text of the button looks like:
```
<span>
   Accept
</span>
```

This PR trims the whitespace around the inner text of an HTML element.

There are also some whitespace removals at the ends of some lines (my editor automatically removes trailing whitespace on save). I can redo the PR without those changes if you wish.